### PR TITLE
Implemented rudimentary OAuth ROPC provider endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "helper-macros",
  "oauth2",
  "once_cell",
+ "rand",
  "reqwest 0.12.7",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ surrealdb-abstraction = { workspace = true }
 helper-macros = { path = "helper-macros" }
 actix-identity = { workspace = true }
 actix-session = { workspace = true }
+rand = { version = "0.8.5", default-features = false }
 
 [features]
 default = ["local"]

--- a/src/auth/oauth/google.rs
+++ b/src/auth/oauth/google.rs
@@ -1,4 +1,3 @@
-use actix_identity::Identity;
 use crate::auth::oauth::error::OauthError;
 use crate::auth::oauth::provider::google::GoogleProvider;
 use crate::auth::oauth::scopes::google::{GoogleScope, GoogleScopes};
@@ -8,8 +7,9 @@ use crate::error::ServerResponseError;
 use crate::models::datetime::Datetime;
 use crate::utils::oauth_client::define_oauth_client;
 use crate::AppState;
-use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Scope};
+use actix_identity::Identity;
 use actix_web::cookie::Cookie;
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Scope};
 use anyhow::Result;
 use helper_macros::generate_endpoint;
 use serde::{Deserialize, Serialize};

--- a/src/auth/oauth/local.rs
+++ b/src/auth/oauth/local.rs
@@ -1,0 +1,22 @@
+use actix_web::{web, HttpResponse, Scope};
+use helper_macros::generate_endpoint;
+
+generate_endpoint! {
+    fn local_login;
+    method: get;
+    path: "/health";
+    docs: {
+        tag: "health",
+        context_path: "/",
+        responses: {
+            (status = 200, description = "Everything works just fine!")
+        }
+    }
+    {
+        Ok(HttpResponse::Ok().body("Everything works just fine!"))
+    }
+}
+
+pub fn local_oauth_service() -> Scope {
+    web::scope("/local").service(local_login)
+}

--- a/src/auth/oauth/local.rs
+++ b/src/auth/oauth/local.rs
@@ -1,4 +1,3 @@
-use crate::auth::oauth::provider::OauthProvider;
 use crate::error::ServerResponseError;
 use crate::state::AppState;
 use actix_web::http::header::CacheDirective;
@@ -10,7 +9,6 @@ use rand::{
     thread_rng,
 };
 use serde::{Deserialize, Serialize};
-use surrealdb::sql::{Datetime, Thing};
 use tracing::info;
 use utoipa::ToSchema;
 
@@ -45,15 +43,6 @@ impl<'a> TokenResponse<'a> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Foo {
-    id: Option<Thing>,
-    providers: Option<Vec<OauthProvider>>,
-    created_at: Datetime,
-    updated_at: Datetime,
-    password: Option<String>,
-}
-
 generate_endpoint! {
     fn local_token;
     method: post;
@@ -62,7 +51,8 @@ generate_endpoint! {
         tag: "token",
         context_path: "/local",
         responses: {
-            (status = 200, description = "Local OAuth provider token endpoint")
+            (status = 200, description = "Access token request successful"),
+            (status = 404, description = "User not found")
         }
     }
     params: {

--- a/src/auth/oauth/local.rs
+++ b/src/auth/oauth/local.rs
@@ -1,3 +1,4 @@
+use crate::auth::users::get::get_user_by_username;
 use crate::state::AppState;
 use actix_web::{web, HttpResponse, Scope};
 use helper_macros::generate_endpoint;
@@ -11,7 +12,7 @@ use tracing::info;
 use utoipa::ToSchema;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "grant_type", rename_all = "lowercase")]
+#[serde(tag = "grant_type", rename_all = "snake_case")]
 enum TokenRequest {
     Password { username: String, password: String },
     RefreshToken { refresh_token: RefreshToken },

--- a/src/auth/oauth/local.rs
+++ b/src/auth/oauth/local.rs
@@ -1,13 +1,15 @@
-use crate::auth::users::get::get_user_by_username;
+use crate::auth::oauth::provider::OauthProvider;
+use crate::error::ServerResponseError;
 use crate::state::AppState;
-use actix_web::{web, HttpResponse, Scope};
-use helper_macros::generate_endpoint;
+use actix_web::http::header::CacheDirective;
+use actix_web::{http::header, web, HttpResponse, Scope};
 use oauth2::{AccessToken, RefreshToken};
 use rand::{
     distributions::{Alphanumeric, DistString},
     thread_rng,
 };
 use serde::{Deserialize, Serialize};
+use surrealdb::sql::{Datetime, Thing};
 use tracing::info;
 use utoipa::ToSchema;
 
@@ -42,24 +44,50 @@ impl<'a> TokenResponse<'a> {
     }
 }
 
-generate_endpoint! {
-    fn local_token;
-    method: post;
-    path: "/token";
-    docs: {
-        tag: "token",
-        context_path: "/local",
-        responses: {
-            (status = 200, description = "Local OAuth provider token endpoint")
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Foo {
+    id: Option<Thing>,
+    providers: Option<Vec<OauthProvider>>,
+    created_at: Datetime,
+    updated_at: Datetime,
+    password: Option<String>,
+}
+
+#[utoipa::path(post,path = "/token",context_path = "/local",tag = "token",responses((status = 200u16,description = "Local OAuth provider token endpoint")))]
+#[actix_web::post("/token")]
+pub async fn local_token(
+    state: web::Data<AppState>,
+    data: web::Form<TokenRequest>,
+) -> Result<impl ::actix_web::Responder, crate::error::ServerResponseError> {
+    info!("Recieved token request: {:?}", &data);
+
+    match data.into_inner() {
+        TokenRequest::RefreshToken { refresh_token } => Err(ServerResponseError::BadRequest(
+            "Refreshing tokens not yet supported".to_string(),
+        )),
+        TokenRequest::Password { username, password } => {
+            let query =
+                r#"SELECT COUNT() FROM user WHERE username = $username AND password = $password;"#;
+            let query_result: Option<i32> = state
+                .db
+                .query(query)
+                .bind(("username", username))
+                .bind(("password", password))
+                .await?
+                .take("count")?;
+
+            let valid_user = query_result.is_some_and(|count| count > 0);
+            if valid_user {
+                Ok(HttpResponse::Ok()
+                    .insert_header(header::CacheControl(vec![
+                        CacheDirective::NoCache,
+                        CacheDirective::NoStore,
+                    ]))
+                    .json(TokenResponse::new()))
+            } else {
+                Err(ServerResponseError::NotFound)
+            }
         }
-    }
-    params: {
-        state: web::Data<AppState>,
-        data: web::Form<TokenRequest>,
-    };
-    {
-        info!("Recieved token request: {:?}", data);
-        Ok(HttpResponse::Ok().json(TokenResponse::new()))
     }
 }
 

--- a/src/auth/oauth/local.rs
+++ b/src/auth/oauth/local.rs
@@ -1,22 +1,55 @@
 use actix_web::{web, HttpResponse, Scope};
 use helper_macros::generate_endpoint;
+use oauth2::{AccessToken, RefreshToken};
+use rand::{
+    distributions::{Alphanumeric, DistString},
+    thread_rng,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The `TokenResponse` type models the response data
+/// of the "/token" endpoint.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct TokenResponse<'a> {
+    access_token: AccessToken,
+    refresh_token: RefreshToken,
+    token_type: &'a str,
+    expires_in: i64,
+}
+
+/// Returns a random alphanumeric string of length `length`.
+fn random_string(length: usize) -> String {
+    Alphanumeric.sample_string(&mut thread_rng(), length)
+}
+
+impl<'a> TokenResponse<'a> {
+    fn new() -> Self {
+        Self {
+            access_token: AccessToken::new(random_string(16)),
+            refresh_token: RefreshToken::new(random_string(16)),
+            token_type: "bearer",
+            expires_in: 3600,
+        }
+    }
+}
 
 generate_endpoint! {
-    fn local_login;
+    fn local_token;
     method: get;
-    path: "/health";
+    path: "/token";
     docs: {
-        tag: "health",
-        context_path: "/",
+        tag: "token",
+        context_path: "/local",
         responses: {
-            (status = 200, description = "Everything works just fine!")
+            (status = 200, description = "Local OAuth provider token endpoint")
         }
     }
     {
-        Ok(HttpResponse::Ok().body("Everything works just fine!"))
+        Ok(HttpResponse::Ok().json(TokenResponse::new()))
     }
 }
 
 pub fn local_oauth_service() -> Scope {
-    web::scope("/local").service(local_login)
+    web::scope("/local").service(local_token)
 }

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -49,6 +49,8 @@ struct OAuthCallbackQuery {
 use github::__path_login as __path_github_login;
 use google::*;
 
+use local::__path_local_token;
+
 #[derive(OpenApi)]
-#[openapi(paths(google_login, github_login), components())]
+#[openapi(paths(google_login, github_login, local_token), components())]
 pub struct OauthApi;

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -2,11 +2,13 @@ pub mod basic;
 pub mod error;
 pub mod github;
 pub mod google;
+pub mod local;
 pub(crate) mod provider;
 pub(crate) mod scopes;
 
 use crate::auth::oauth::github::{github_oauth_service, GithubOauth};
 use crate::auth::oauth::google::google_oauth_service;
+use crate::auth::oauth::local::local_oauth_service;
 use actix_web::{web, Scope};
 use anyhow::Result;
 pub use google::GoogleOauth;
@@ -32,6 +34,7 @@ pub fn oauth_service() -> Scope {
     web::scope("/oauth")
         .service(google_oauth_service())
         .service(github_oauth_service())
+        .service(local_oauth_service())
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
I have implemented a basic OAuth endpoint that supports the OAuth "Resource Owner Password Credentials" grant type. See [RFC 6749 section 4.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.3) for the spec. The endpoints accepts requests containing a username and (plaintext) password and will return an access token and a refresh token if the user is valid. The endpoint does not yet support refreshing expired access tokens. OpenAPI documentation for this endpoint has not yet been implemented since implementing this for enum types turned out to be complicated.