### PR TITLE
Created API endpoint for updating user data

### DIFF
--- a/migrations/20241111_154704_set_url_safe_username_autogenerated_from_username.surql
+++ b/migrations/20241111_154704_set_url_safe_username_autogenerated_from_username.surql
@@ -1,0 +1,1 @@
+DEFINE FIELD OVERWRITE url_safe_username ON user VALUE string::slug($this.username);

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -27,7 +27,7 @@ pub struct UserInfo {
     #[schema(example = "johndoe@example.com")]
     pub email: String,
     #[schema(example = "johndoe")]
-    pub url_safe_username: String,
+    pub url_safe_username: Option<String>,
     #[schema(example = "John Doe")]
     pub username: String,
     #[schema(example = "John")]

--- a/src/auth/oauth/github.rs
+++ b/src/auth/oauth/github.rs
@@ -1,6 +1,7 @@
 use super::provider::github::GithubProvider;
 use super::scopes::github::{GithubScope, GithubScopes};
 use crate::auth::oauth::error::OauthError;
+use crate::auth::oauth::url_safe_string;
 use crate::auth::oauth::OAuthCallbackQuery;
 use crate::auth::{Role, UserInfo};
 use crate::error::ServerResponseError;
@@ -62,11 +63,7 @@ define_oauth_client!(
         base_url_env: "BASE_URL",
         default_base_url: "http://localhost:9999",
         user_info_mapping: |github_user_info| {
-            let safe_username = {
-                let mut username = github_user_info.login.clone().to_lowercase();
-                username.retain(|c| c.is_ascii_alphanumeric() || c == '_');
-                username
-            };
+            let safe_username = url_safe_string(&github_user_info.login);
 
             Ok::<UserInfo, OauthError>(UserInfo {
                 id: None,

--- a/src/auth/oauth/github.rs
+++ b/src/auth/oauth/github.rs
@@ -1,7 +1,6 @@
 use super::provider::github::GithubProvider;
 use super::scopes::github::{GithubScope, GithubScopes};
 use crate::auth::oauth::error::OauthError;
-use crate::auth::oauth::url_safe_string;
 use crate::auth::oauth::OAuthCallbackQuery;
 use crate::auth::{Role, UserInfo};
 use crate::error::ServerResponseError;
@@ -63,12 +62,10 @@ define_oauth_client!(
         base_url_env: "BASE_URL",
         default_base_url: "http://localhost:9999",
         user_info_mapping: |github_user_info| {
-            let safe_username = url_safe_string(&github_user_info.login);
-
             Ok::<UserInfo, OauthError>(UserInfo {
                 id: None,
                 email: github_user_info.email.unwrap_or_default(),
-                url_safe_username: safe_username,
+                url_safe_username: None,
                 username: github_user_info.name.unwrap_or_else(|| github_user_info.login.clone()),
                 first_name: "".to_string(),
                 last_name: "".to_string(),

--- a/src/auth/oauth/google.rs
+++ b/src/auth/oauth/google.rs
@@ -1,6 +1,7 @@
 use crate::auth::oauth::error::OauthError;
 use crate::auth::oauth::provider::google::GoogleProvider;
 use crate::auth::oauth::scopes::google::{GoogleScope, GoogleScopes};
+use crate::auth::oauth::url_safe_string;
 use crate::auth::oauth::OAuthCallbackQuery;
 use crate::auth::{Role, UserInfo};
 use crate::error::ServerResponseError;
@@ -28,12 +29,7 @@ pub struct GoogleUserInfo {
 
 impl From<GoogleUserInfo> for UserInfo {
     fn from(user_info: GoogleUserInfo) -> Self {
-        let safe_username = {
-            let mut username = user_info.name.clone().to_lowercase();
-            username.retain(|c| c.is_ascii());
-            username.retain(|c| c.is_alphanumeric() || c == '_');
-            username
-        };
+        let safe_username = url_safe_string(&user_info.name);
 
         Self {
             id: None,

--- a/src/auth/oauth/google.rs
+++ b/src/auth/oauth/google.rs
@@ -1,7 +1,6 @@
 use crate::auth::oauth::error::OauthError;
 use crate::auth::oauth::provider::google::GoogleProvider;
 use crate::auth::oauth::scopes::google::{GoogleScope, GoogleScopes};
-use crate::auth::oauth::url_safe_string;
 use crate::auth::oauth::OAuthCallbackQuery;
 use crate::auth::{Role, UserInfo};
 use crate::error::ServerResponseError;
@@ -29,12 +28,10 @@ pub struct GoogleUserInfo {
 
 impl From<GoogleUserInfo> for UserInfo {
     fn from(user_info: GoogleUserInfo) -> Self {
-        let safe_username = url_safe_string(&user_info.name);
-
         Self {
             id: None,
             email: user_info.email,
-            url_safe_username: safe_username,
+            url_safe_username: None,
             username: user_info.name,
             first_name: user_info.given_name,
             last_name: user_info.family_name,

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -68,9 +68,7 @@ use github::__path_login as __path_github_login;
 use google::*;
 
 use crate::auth::oauth::register::__path_register_endpoint;
-use crate::auth::oauth::update::{
-    UserInfoUpdateRequest, UserUpdateRequest, __path_user_update_endpoint,
-};
+use crate::auth::oauth::update::{UserUpdateRequest, __path_user_update_endpoint};
 use crate::models::{access_token::AccessToken, refresh_token::RefreshToken};
 use local::{TokenRequest, TokenResponse, TokenResponseExample, TokenType, __path_token};
 use logout::__path_logout;
@@ -93,7 +91,6 @@ use logout::__path_logout;
             TokenResponse,
             TokenType,
             UserRegistrationRequest,
-            UserInfoUpdateRequest,
             UserUpdateRequest
         ),
         responses(TokenResponseExample)

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -7,11 +7,13 @@ pub mod logout;
 pub(crate) mod provider;
 pub mod register;
 pub(crate) mod scopes;
+pub mod update;
 
 use crate::auth::oauth::github::{github_oauth_service, GithubOauth};
 use crate::auth::oauth::google::{google_oauth_service, GoogleOauth};
 use crate::auth::oauth::local::token;
 use crate::auth::oauth::register::register_endpoint;
+use crate::auth::oauth::update::user_update_endpoint;
 use actix_web::guard::Acceptable;
 use actix_web::{web, Scope};
 use anyhow::Result;
@@ -43,6 +45,7 @@ pub fn oauth_service() -> Scope {
         .guard(Acceptable::new(mime::APPLICATION_JSON).match_star_star())
         .service(token)
         .service(register_endpoint)
+        .service(user_update_endpoint)
 }
 
 #[allow(dead_code)]
@@ -58,13 +61,23 @@ use github::__path_login as __path_github_login;
 use google::*;
 
 use crate::auth::oauth::register::__path_register_endpoint;
+use crate::auth::oauth::update::{
+    UserInfoUpdateRequest, UserUpdateRequest, __path_user_update_endpoint,
+};
 use crate::models::{access_token::AccessToken, refresh_token::RefreshToken};
 use local::{TokenRequest, TokenResponse, TokenResponseExample, TokenType, __path_token};
 use logout::__path_logout;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(google_login, github_login, token, logout, register_endpoint),
+    paths(
+        google_login,
+        github_login,
+        token,
+        logout,
+        register_endpoint,
+        user_update_endpoint
+    ),
     components(
         schemas(
             AccessToken,
@@ -72,7 +85,9 @@ use logout::__path_logout;
             TokenRequest,
             TokenResponse,
             TokenType,
-            UserRegistrationRequest
+            UserRegistrationRequest,
+            UserInfoUpdateRequest,
+            UserUpdateRequest
         ),
         responses(TokenResponseExample)
     )

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -22,6 +22,13 @@ use register::UserRegistrationRequest;
 use serde::Deserialize;
 use utoipa::{IntoParams, OpenApi};
 
+pub(crate) fn url_safe_string(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_')
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct Oauth {
     pub google: GoogleOauth,

--- a/src/auth/oauth/mod.rs
+++ b/src/auth/oauth/mod.rs
@@ -22,13 +22,6 @@ use register::UserRegistrationRequest;
 use serde::Deserialize;
 use utoipa::{IntoParams, OpenApi};
 
-pub(crate) fn url_safe_string(s: &str) -> String {
-    s.to_lowercase()
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_')
-        .collect()
-}
-
 #[derive(Debug, Clone)]
 pub struct Oauth {
     pub google: GoogleOauth,

--- a/src/auth/oauth/register.rs
+++ b/src/auth/oauth/register.rs
@@ -1,18 +1,22 @@
-use crate::auth::{users::create::register_user};
+use crate::auth::users::create::register_user;
 use crate::state::AppState;
 use actix_web::{web, HttpResponse};
 use helper_macros::generate_endpoint;
 use serde::{Deserialize, Serialize};
-use utoipa::{IntoParams, ToSchema};
+use utoipa::ToSchema;
 
-/// Contains the data used to register a new user. This involves
-/// creating new entries in both the 'user' and 'user_auth' tables.
-#[derive(Serialize, Deserialize, ToSchema, IntoParams)]
-pub struct UserRegistrationRequest {
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct UserCreationRequest {
     pub username: String,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     pub email: String,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct UserRegistrationRequest {
+    #[serde(flatten)]
+    pub user: UserCreationRequest,
     pub password: String,
 }
 

--- a/src/auth/oauth/register.rs
+++ b/src/auth/oauth/register.rs
@@ -1,11 +1,12 @@
-use crate::auth::users::create::register_user;
-use crate::auth::UserInfo;
+use crate::auth::{users::create::register_user};
 use crate::state::AppState;
 use actix_web::{web, HttpResponse};
 use helper_macros::generate_endpoint;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
+/// Contains the data used to register a new user. This involves
+/// creating new entries in both the 'user' and 'user_auth' tables.
 #[derive(Serialize, Deserialize, ToSchema, IntoParams)]
 pub struct UserRegistrationRequest {
     pub username: String,
@@ -13,20 +14,6 @@ pub struct UserRegistrationRequest {
     pub last_name: Option<String>,
     pub email: String,
     pub password: String,
-}
-
-impl From<UserRegistrationRequest> for UserInfo {
-    fn from(value: UserRegistrationRequest) -> Self {
-        Self {
-            id: None,
-            email: value.email,
-            url_safe_username: value.username.clone(),
-            username: value.username,
-            first_name: value.first_name.unwrap_or_default(),
-            last_name: value.last_name.unwrap_or_default(),
-            ..Default::default()
-        }
-    }
 }
 
 generate_endpoint! {

--- a/src/auth/oauth/update.rs
+++ b/src/auth/oauth/update.rs
@@ -1,0 +1,102 @@
+use crate::auth::users::get::utils::get_user_by_token;
+use crate::error::ServerResponseError;
+use crate::extractors::AuthenticatedToken;
+use crate::extractors::IntoSession;
+use crate::generate_endpoint;
+use crate::models::thing::Thing;
+use crate::state::AppState;
+use actix_web::{web, HttpResponse};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use surrealdb::Surreal;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UserInfoUpdateRequest {
+    pub username: String,
+    pub first_name: String,
+    pub last_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UserUpdateRequest {
+    #[serde(flatten)]
+    pub user_info_update: Option<UserInfoUpdateRequest>,
+    pub password: Option<String>,
+}
+
+fn url_safe_string(s: String) -> String {
+    s.to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_')
+        .collect()
+}
+
+pub async fn update_user_data<T>(
+    db: &Arc<Surreal<T>>,
+    user_id: Thing,
+    update_data: UserUpdateRequest,
+) -> Result<(), ServerResponseError>
+where
+    T: surrealdb::Connection,
+{
+    if let Some(user_info_update) = update_data.user_info_update {
+        let url_safe_username = url_safe_string(user_info_update.username.clone());
+        const SQL: &str = "UPDATE $user_id SET
+		username = $username,
+		url_safe_username = $url_safe_username,
+		first_name = $first_name,
+		last_name = $last_name;";
+        db.query(SQL)
+            .bind(("user_id", user_id.clone()))
+            .bind(("username", user_info_update.username))
+            .bind(("url_safe_username", url_safe_username))
+            .bind(("first_name", user_info_update.first_name))
+            .bind(("last_name", user_info_update.last_name))
+            .await?;
+    }
+
+    if let Some(password) = update_data.password {
+        const SQL: &str = "UPDATE user_auth SET password = $new_password WHERE ->auth_for->user.id CONTAINS $user_id;";
+        db.query(SQL)
+            .bind(("new_password", password))
+            .bind(("user_id", user_id))
+            .await?;
+    }
+    Ok(())
+}
+
+generate_endpoint! {
+    fn user_update_endpoint;
+    method: put;
+    path: "/update";
+    docs: {
+        tag: "oauth",
+        responses: {
+            (status = 200, description = "User updated successfully"),
+            (status = 401, description = "Not logged in"),
+            (status = 404, description = "User not found or invalid credentials"),
+            (status = 500, description = "An error occurred when updating user information in the database"),
+        },
+        security: [
+            ("bearer_token" = []),
+            ("cookie_session" = []),
+        ]
+    }
+    params: {
+        data: web::Json<UserUpdateRequest>,
+        token: AuthenticatedToken,
+        state: web::Data<AppState>,
+    };
+    {
+        let access_token = token.get_token();
+        let user = get_user_by_token(&state.db, &access_token).await?;
+        let Some(user_id) = user.id else {
+            return Err(ServerResponseError::NotFound);
+        };
+        let update_data = data.into_inner();
+
+        update_user_data(&state.db, user_id, update_data).await?;
+        Ok(HttpResponse::Ok().finish())
+    }
+}

--- a/src/auth/oauth/update.rs
+++ b/src/auth/oauth/update.rs
@@ -1,4 +1,3 @@
-use crate::auth::oauth::url_safe_string;
 use crate::auth::users::get::utils::get_user_by_token;
 use crate::error::ServerResponseError;
 use crate::extractors::AuthenticatedToken;
@@ -28,7 +27,6 @@ pub async fn update_user_data<T>(
 where
     T: surrealdb::Connection,
 {
-    let url_safe_username = url_safe_string(&update_data.username);
     const SQL: &str = "UPDATE $user_id SET
 		username = $username,
 		url_safe_username = $url_safe_username,
@@ -37,7 +35,6 @@ where
     db.query(SQL)
         .bind(("user_id", user_id.clone()))
         .bind(("username", update_data.username))
-        .bind(("url_safe_username", url_safe_username))
         .bind(("first_name", update_data.first_name))
         .bind(("last_name", update_data.last_name))
         .await?;

--- a/src/auth/oauth/update.rs
+++ b/src/auth/oauth/update.rs
@@ -13,16 +13,10 @@ use surrealdb::Surreal;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct UserInfoUpdateRequest {
+pub struct UserUpdateRequest {
     pub username: String,
     pub first_name: String,
     pub last_name: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct UserUpdateRequest {
-    #[serde(flatten)]
-    pub user_info_update: Option<UserInfoUpdateRequest>,
     pub password: Option<String>,
 }
 
@@ -34,21 +28,19 @@ pub async fn update_user_data<T>(
 where
     T: surrealdb::Connection,
 {
-    if let Some(user_info_update) = update_data.user_info_update {
-        let url_safe_username = url_safe_string(&user_info_update.username);
-        const SQL: &str = "UPDATE $user_id SET
+    let url_safe_username = url_safe_string(&update_data.username);
+    const SQL: &str = "UPDATE $user_id SET
 		username = $username,
 		url_safe_username = $url_safe_username,
 		first_name = $first_name,
 		last_name = $last_name;";
-        db.query(SQL)
-            .bind(("user_id", user_id.clone()))
-            .bind(("username", user_info_update.username))
-            .bind(("url_safe_username", url_safe_username))
-            .bind(("first_name", user_info_update.first_name))
-            .bind(("last_name", user_info_update.last_name))
-            .await?;
-    }
+    db.query(SQL)
+        .bind(("user_id", user_id.clone()))
+        .bind(("username", update_data.username))
+        .bind(("url_safe_username", url_safe_username))
+        .bind(("first_name", update_data.first_name))
+        .bind(("last_name", update_data.last_name))
+        .await?;
 
     if let Some(password) = update_data.password {
         const SQL: &str = "UPDATE user_auth SET password = $new_password WHERE ->auth_for->user.id CONTAINS $user_id;";

--- a/src/auth/oauth/update.rs
+++ b/src/auth/oauth/update.rs
@@ -1,3 +1,4 @@
+use crate::auth::oauth::url_safe_string;
 use crate::auth::users::get::utils::get_user_by_token;
 use crate::error::ServerResponseError;
 use crate::extractors::AuthenticatedToken;
@@ -25,13 +26,6 @@ pub struct UserUpdateRequest {
     pub password: Option<String>,
 }
 
-fn url_safe_string(s: String) -> String {
-    s.to_lowercase()
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_')
-        .collect()
-}
-
 pub async fn update_user_data<T>(
     db: &Arc<Surreal<T>>,
     user_id: Thing,
@@ -41,7 +35,7 @@ where
     T: surrealdb::Connection,
 {
     if let Some(user_info_update) = update_data.user_info_update {
-        let url_safe_username = url_safe_string(user_info_update.username.clone());
+        let url_safe_username = url_safe_string(&user_info_update.username);
         const SQL: &str = "UPDATE $user_id SET
 		username = $username,
 		url_safe_username = $url_safe_username,

--- a/src/auth/users/create.rs
+++ b/src/auth/users/create.rs
@@ -62,7 +62,7 @@ where
     ";
 
     db.query(REGISTER_USER_SQL)
-        .bind(("user_content", user_registration))
+        .bind(("user_content", user_registration.user))
         .bind(("password", password))
         .await?
         .check()?;

--- a/src/auth/users/create.rs
+++ b/src/auth/users/create.rs
@@ -10,12 +10,11 @@ pub async fn create_user<T>(db: &Arc<Surreal<T>>, user: UserInfo) -> Result<Reco
 where
     T: surrealdb::Connection,
 {
-    let sql = "CREATE user SET username = $username, url_safe_username = $url_safe_username, first_name = $first_name, last_name = $last_name, email = $email, picture = $picture, role = $role";
+    let sql = "CREATE user SET username = $username, first_name = $first_name, last_name = $last_name, email = $email, picture = $picture, role = $role";
 
     let mut res = db
         .query(sql)
         .bind(("username", user.username.clone()))
-        .bind(("url_safe_username", user.url_safe_username.clone()))
         .bind(("first_name", user.first_name.clone()))
         .bind(("last_name", user.last_name.clone()))
         .bind(("email", user.email.clone()))
@@ -43,7 +42,6 @@ where
     T: surrealdb::Connection,
 {
     let password = user_registration.password.clone();
-    let user = UserInfo::from(user_registration);
 
     const REGISTER_USER_SQL: &str = "
         BEGIN TRANSACTION;
@@ -64,7 +62,7 @@ where
     ";
 
     db.query(REGISTER_USER_SQL)
-        .bind(("user_content", user))
+        .bind(("user_content", user_registration))
         .bind(("password", password))
         .await?
         .check()?;

--- a/src/dto/user_info.rs
+++ b/src/dto/user_info.rs
@@ -6,7 +6,7 @@ create_dto! {
     UserInfo,
     struct UserInfoDTO {
         pub email: String,
-        pub url_safe_username: String,
+        pub url_safe_username: Option<String>,
         pub username: String,
         pub first_name: String,
         pub last_name: String,


### PR DESCRIPTION
Ok, let's try this again.

This PR adds an API endpoint for updating user information. The fields that can be changed are the username, first and last name, and password. The endpoint uses the PUT method. When the username is updated, the URL safe username is updated accordingly. There is Utoipa API documentation for the endpoint, but it is not perfect. There's some problem with the schema for the type representing the request data format for the endpoint.