### PR TITLE
Ran 'cargo clippy --fix' on 'helper-macros' crate.

### DIFF
--- a/helper-macros/src/generate_crud/crud_operation.rs
+++ b/helper-macros/src/generate_crud/crud_operation.rs
@@ -251,7 +251,7 @@ impl CrudOperation {
             }
         };
 
-        TokenStream::from(tokens)
+        tokens
     }
 }
 

--- a/helper-macros/src/generate_endpoint.rs
+++ b/helper-macros/src/generate_endpoint.rs
@@ -34,7 +34,7 @@ use syn::{
 pub(crate) fn generate_endpoint_internal(input: TokenStream) -> TokenStream1 {
     let input: TokenStream1 = input.into();
 
-    let input = parse_macro_input!(input as GenerateEndpointInput).into();
+    let input = parse_macro_input!(input as GenerateEndpointInput);
 
     let GenerateEndpointInput {
         attrs,
@@ -221,13 +221,13 @@ pub(crate) struct SecurityRequirement {
 
 impl Parse for SecurityRequirement {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let name;
+        
         let mut scopes = Vec::new();
 
         let content;
         parenthesized!(content in input);
 
-        name = content.parse().ok();
+        let name = content.parse().ok();
 
         if let Some(_name) = &name {
             content.parse::<Token![=]>()?;

--- a/helper-macros/src/lib.rs
+++ b/helper-macros/src/lib.rs
@@ -32,11 +32,11 @@ mod generate_endpoint;
 ///```
 ///
 pub fn generate_endpoint(input: TokenStream) -> TokenStream {
-    generate_endpoint_internal(input.into()).into()
+    generate_endpoint_internal(input.into())
 }
 
 #[proc_macro_error]
 #[proc_macro]
 pub fn generate_crud(input: TokenStream) -> TokenStream {
-    generate_crud_internal(input.into()).into()
+    generate_crud_internal(input.into())
 }


### PR DESCRIPTION
I ran cargo clippy --fix on the helper-macros crate. This gives us a clean cargo clippy output, making it easier to catch other warnings, etc.