### PR TITLE
Created API endpoint to delete a user

### DIFF
--- a/src/endpoints/api/user/delete.rs
+++ b/src/endpoints/api/user/delete.rs
@@ -1,0 +1,42 @@
+use crate::error::ServerResponseError;
+use crate::extractors::AuthenticatedToken;
+use crate::extractors::IntoSession;
+use crate::generate_endpoint;
+use crate::models::UserInfo;
+use crate::services::user::delete::delete_user;
+use crate::services::user::get::get_user_by_token;
+use crate::state::AppState;
+use actix_web::{web, HttpResponse};
+use utoipa::ToSchema;
+
+generate_endpoint! {
+    fn delete_user_endpoint;
+    method: delete;
+    path: "";
+    docs: {
+        tag: "user",
+        responses: {
+            (status = 200, description = "User deleted successfully"),
+            (status = 401, description = "Not logged in"),
+            (status = 404, description = "User not found or invalid credentials"),
+            (status = 500, description = "An error occurred when deleting user in the database"),
+        },
+        security: [
+            ("bearer_token" = []),
+            ("cookie_session" = []),
+        ]
+    }
+    params: {
+        token: AuthenticatedToken,
+        state: web::Data<AppState>,
+    };
+    {
+        let access_token = token.get_token();
+        let user = get_user_by_token(&state.db, &access_token).await?;
+        let Some(user_id) = user.id else {
+            return Err(ServerResponseError::NotFound);
+        };
+        delete_user(&state.db , user_id).await?;
+        Ok(HttpResponse::Ok().finish())
+    }
+}

--- a/src/endpoints/api/user/mod.rs
+++ b/src/endpoints/api/user/mod.rs
@@ -1,6 +1,8 @@
+pub mod delete;
 pub mod get;
 pub mod update;
 
+use crate::endpoints::user::delete::*;
 use crate::endpoints::user::get::*;
 use crate::endpoints::user::update::*;
 use crate::extractors::Authenticated;
@@ -17,7 +19,7 @@ use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(get_user_by, update_user),
+    paths(get_user_by, update_user, delete_user_endpoint),
     components(
         schemas(Role, UserInfo, GetUserBy),
         responses(UserInfoExampleResponses)
@@ -30,4 +32,5 @@ pub fn user_service() -> impl actix_web::dev::HttpServiceFactory {
         .guard(Acceptable::new(mime::APPLICATION_JSON).match_star_star())
         .service(get_user_by)
         .service(update_user)
+        .service(delete_user_endpoint)
 }

--- a/src/services/user/delete.rs
+++ b/src/services/user/delete.rs
@@ -1,0 +1,19 @@
+use crate::error::ServerResponseError;
+use crate::models::thing::Thing;
+use std::sync::Arc;
+use surrealdb::Surreal;
+
+pub async fn delete_user<T>(db: &Arc<Surreal<T>>, user_id: Thing) -> Result<(), ServerResponseError>
+where
+    T: surrealdb::Connection,
+{
+    const SQL: &str = "
+            BEGIN TRANSACTION;
+            DELETE user_auth WHERE ->auth_for->user.id CONTAINS $USER_ID;
+            DELETE $USER_ID;
+            COMMIT TRANSACTION;
+        ";
+    db.query(SQL).bind(("USER_ID", user_id)).await?;
+
+    Ok(())
+}

--- a/src/services/user/mod.rs
+++ b/src/services/user/mod.rs
@@ -1,3 +1,4 @@
 pub mod create;
+pub mod delete;
 pub mod get;
 pub mod update;


### PR DESCRIPTION
Added API endpoint "DELETE /api/v1/user" to delete a user. I needed to manually delete the user's "user_auth" record before deleting the "user" record. This is supposed to happen automatically when a "user" record is deleted, but this did not work.

@EmEhPa is working on the frontend functionality for this feature.